### PR TITLE
Local auth example improvements

### DIFF
--- a/auth/local/auth/composables/auth.ts
+++ b/auth/local/auth/composables/auth.ts
@@ -8,9 +8,9 @@ export const authLogin = async (email: string, password: string) => {
       password: password,
     },
   });
-  useAuth().redirectTo.value = null;
+  const { redirectTo } = useRoute().query;
   await useAuth().updateSession();
-  await navigateTo(useAuth().redirectTo.value || "/");
+  await navigateTo(String(redirectTo) || "/");
 };
 
 export const authRegister = async (email: string, password: string) => {

--- a/auth/local/auth/nuxt.config.ts
+++ b/auth/local/auth/nuxt.config.ts
@@ -15,7 +15,7 @@ export default defineNuxtConfig({
   },
   nitro: {
     storage: {
-      ".data:auth": { driver: "fs", base: "./.data/auth" },
+      "db:auth": { driver: "fs", base: "./.data/auth" },
     },
   },
 });

--- a/auth/local/pages/login.vue
+++ b/auth/local/pages/login.vue
@@ -10,7 +10,7 @@ const isValid = computed(() => {
   return email.value && password.value;
 });
 
-const redirectTo = useAuth().redirectTo.value
+const { redirectTo } = useRoute().query;
 const alert = ref(
   `Please login or register ${redirectTo ? `to access ${redirectTo}` : ""}`
 );

--- a/auth/local/pages/profile.vue
+++ b/auth/local/pages/profile.vue
@@ -7,7 +7,7 @@ definePageMeta({
   auth: true,
 });
 
-const { data: session } = await useFetch("/api/auth/session", { headers: useRequestHeaders(['cookie'])});
+const { data: session } = await useFetch("/api/auth/session");
 </script>
 
 <template>


### PR DESCRIPTION
This change is to improve the Local Auth example by supporting redirecting back to the place you were at before being logged out in a server page load context. In other words, you could be on /secret, and delete your cookies. When you try to login via hard load of /secret, the login page will be aware of where you previously were, and correctly bring you back to /secret. 

This may require some more work, as you do see the 'protected' page for an instant during the redirect. 