### PR TITLE
fix: add missing tsconfig files

### DIFF
--- a/advanced/config-extends/server/tsconfig.json
+++ b/advanced/config-extends/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/advanced/error-handling/server/tsconfig.json
+++ b/advanced/error-handling/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/auth/local/server/tsconfig.json
+++ b/auth/local/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/experimental/wasm/server/tsconfig.json
+++ b/experimental/wasm/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/features/data-fetching/server/tsconfig.json
+++ b/features/data-fetching/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../.nuxt/tsconfig.server.json"
+}

--- a/ui/daisyui/tsconfig.json
+++ b/ui/daisyui/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/ui/sass/tsconfig.json
+++ b/ui/sass/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/ui/tailwindcss/tsconfig.json
+++ b/ui/tailwindcss/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}

--- a/ui/vuetify/tsconfig.json
+++ b/ui/vuetify/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./.nuxt/tsconfig.json"
+}


### PR DESCRIPTION
The examples in the `ui/` folder had no `tsconfig.json` files, and because of this TypeScript showed the following error in these projects' `nuxt.config.ts` files: "Cannot find name 'defineNuxtConfig'"

The other files I've added are all for the `server` directories.