### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/advanced/config-extends/base/composables/foo.ts
+++ b/advanced/config-extends/base/composables/foo.ts
@@ -1,3 +1,3 @@
-import { useState } from '#app'
+import { useState } from '#imports'
 
 export const useFoo = () => useState('foo', () => 'foo')

--- a/advanced/error-handling/app.vue
+++ b/advanced/error-handling/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { showError } from '#app'
+import { showError } from '#imports'
 const route = useRoute()
 if ('setup' in route.query) {
   throw new Error('error in setup')


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.