### PR TITLE
Update index.vue of config-extends example

### DIFF
--- a/examples/advanced/config-extends/pages/index.vue
+++ b/examples/advanced/config-extends/pages/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-const themeConfig = useRuntimeConfig().theme
+const themeConfig = useRuntimeConfig().public.theme
 const appConfig = useAppConfig()
 const foo = useFoo()
 const bar = getBar()


### PR DESCRIPTION
Fixed the dot path in the `useRuntimeConfig()` to display correctly the theme