### PR TITLE
Fix route timer issue by preventing multiple timers from running simultaneously

### DIFF
--- a/examples/routing/universal-router/plugins/add.ts
+++ b/examples/routing/universal-router/plugins/add.ts
@@ -2,15 +2,23 @@ export default defineNuxtPlugin(() => {
   const timer = useState('timer', () => 0)
 
   if (process.client) {
+    let timerRunning = false;
     addRouteMiddleware(async () => {
+      if (timerRunning) return;
+
       console.log('Starting timer...')
+      timerRunning = true;
       timer.value = 5
+
       do {
         await new Promise(resolve => setTimeout(resolve, 100))
+        console.log('Timer:', timer.value)
         timer.value--
-      } while (timer.value)
+      } while (timer.value > 0)
+
       console.log('...and navigating')
-    })
+      timerRunning = false;
+    });
   }
 
   addRouteMiddleware((to) => {
@@ -31,3 +39,4 @@ export default defineNuxtPlugin(() => {
     return '/secret'
   })
 })
+


### PR DESCRIPTION
### Description
This pull request fixes an issue where the timer would go into a negative countdown when the navigation link is clicked multiple times rapidly. The issue was caused by multiple overlapping timer instances running simultaneously.

### Fix
- Introduced a `timerRunning` flag to check if a timer is already running before starting a new one.
- Set `timerRunning` to `true` when the timer starts and to `false` when it completes.
