### PR TITLE
fix(teleports): use '#teleports' target instead of 'body'

### DIFF
--- a/examples/advanced/teleport/app.vue
+++ b/examples/advanced/teleport/app.vue
@@ -2,7 +2,7 @@
   <NuxtExample dir="advanced/teleport">
     <div>
       <!-- SSR Teleport -->
-      <Teleport to="body">
+      <Teleport to="#teleports">
         <UContainer>
           <UAlert class="mt-8" icon="i-heroicons-server-stack" title="SSR Teleport" description="Hello from Server-side teleport!" />
         </UContainer>
@@ -10,7 +10,7 @@
 
       <!-- Client Teleport -->
       <ClientOnly>
-        <Teleport to="body">
+        <Teleport to="#teleports">
           <UContainer>
             <UAlert class="mb-8" icon="i-heroicons-window" title="Client Teleport" description="Hello from Client-side teleport!" />
           </UContainer>

--- a/examples/advanced/teleport/components/MyModal.vue
+++ b/examples/advanced/teleport/components/MyModal.vue
@@ -10,7 +10,7 @@ const open = ref(false)
   <UButton @click="open = true">
     Open Modal
   </UButton>
-  <Teleport to="body">
+  <Teleport to="#teleports">
     <div v-if="open" class="fixed inset-0 bg-black/30 backdrop-blur" />
     <UCard v-if="open" class="modal p4">
       <template #header>


### PR DESCRIPTION
### 🔗 Linked issue
https://github.com/nuxt/nuxt/issues/28483

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Changed the recommended teleport target to `'#teleports'`.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
