### PR TITLE
docs: replace 'Nuxt 3' with 'Nuxt'

### DIFF
--- a/.docs/0.hello-world.md
+++ b/.docs/0.hello-world.md
@@ -1,7 +1,7 @@
 ---
 toc: false
 title: Hello World
-description: 'A minimal Nuxt 3 application only requires the `app.vue` and `nuxt.config.js` files.'
+description: 'A minimal Nuxt application only requires the `app.vue` and `nuxt.config.js` files.'
 ---
 
 :read-more{to="/docs/getting-started/introduction"}

--- a/.docs/1.features/2.data-fetching.md
+++ b/.docs/1.features/2.data-fetching.md
@@ -1,7 +1,7 @@
 ---
 toc: false
 title: Data Fetching
-description: 'This example demonstrates data fetching with Nuxt 3 using built-in composables and API routes.'
+description: 'This example demonstrates data fetching with Nuxt using built-in composables and API routes.'
 ---
 
 :read-more{to="/docs/getting-started/data-fetching"}

--- a/.docs/7.experimental/wasm.md
+++ b/.docs/7.experimental/wasm.md
@@ -1,7 +1,7 @@
 ---
 toc: false
 title: 'WASM'
-description: 'This example demonstrates the server-side support of WebAssembly in Nuxt 3.'
+description: 'This example demonstrates the server-side support of WebAssembly in Nuxt.'
 ---
 
 :sandbox{repo="nuxt/examples" branch="main" dir="examples/experimental/wasm" file="app.vue"}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nuxt 3 Examples
+# Nuxt Examples
 
 👉 https://nuxt.com/docs/examples
 

--- a/examples/auth/local/README.md
+++ b/examples/auth/local/README.md
@@ -6,7 +6,7 @@ This project uses [Nuxt Extend Layers](https://nuxt.com/docs/getting-started/lay
 
 Default database is using built-in key-value storage. You can rewrite it with a custom database by updating [`./auth/server/utils/db.ts`](./auth/server/utils/db.ts)
 
-Look at the [Nuxt 3 documentation](https://nuxt.com/docs/getting-started/introduction) to learn more about Nuxt.
+Look at the [Nuxt documentation](https://nuxt.com/docs/getting-started/introduction) to learn more about Nuxt.
 
 ## Setup
 

--- a/examples/features/README.md
+++ b/examples/features/README.md
@@ -1,3 +1,3 @@
-# Nuxt 3 Examples
+# Nuxt Examples
 
 👉 https://nuxt.com/docs/examples


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaced all instances of "Nuxt 3" with "Nuxt" throughout the documentation
