### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-shell-emulator=true

--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "typescript": "6.0.3",
     "vue-tsc": "3.2.8"
   },
-  "packageManager": "pnpm@10.33.4"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,5 +16,7 @@ overrides:
 shellEmulator: true
 
 allowBuilds:
+  "@parcel/watcher": false
   esbuild: false
+  unrs-resolver: false
   vue-demi: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,12 +3,8 @@ packages:
   - examples/**
   - .e2e
   - '!**/.vercel/**'
-ignoredBuiltDependencies:
-  - esbuild
-  - vue-demi
 patchedDependencies:
   '@nuxtjs/tailwindcss': patches/@nuxtjs__tailwindcss.patch
-
 
 overrides:
   "@nuxt/examples-ui": "workspace:*"
@@ -16,3 +12,9 @@ overrides:
   "@vue/shared": "3.5.34"
   nuxt: "4.1.0"
   vue: "3.5.34"
+
+shellEmulator: true
+
+allowBuilds:
+  esbuild: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`